### PR TITLE
fix: performance tweak.

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -264,10 +264,10 @@ namespace CryptoNote
     const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          // 5 seconds
     const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
-    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 1024; // 1 GB
-    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 1024; // 1 GB
-    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 500; // 500 files
-    const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 10; // 10 DB threads
+    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 256; // 256 MB
+    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 64; // 64 MB
+    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 200; // 200 files
+    const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 4; // 4 DB threads
 
     const char     LATEST_VERSION_URL[]                          = "https://www.cryptocatalyst.net";
     const std::string LICENSE_URL                                = "https://github.com/catalystdevelopment/catalyst/blob/development/LICENSE";


### PR DESCRIPTION
Thanks to: https://github.com/bobbieltd/derogold/commit/81f11906fc78116c442c402b6fa827ec5ce0509a
- Exchanges will delist or refuse to list small coins if this shit keeps to be applied
- No impact on performance (even quicker better on low end hardware nodes)

256 Mb write is enough. 
Read buffer is unimportant (it shares with OS cache). 
Opening files : few hundreds is enough. 
Back threads 4 (well 4 cores already enough)
The original dev put 10 Mb (he was not stupid because it is idiot to put big number there)
Turtle dev applied that commit in hurry without much consideration
From outside dev
Background threads = 10 —> assumption people run CPU with 16 cores or what ? Normally,
daemon won’t use many threads but in the worst scenario it will use 10 cores
Those config numbers are for worst case. 
In normal circumstances, daemon utilizes less.